### PR TITLE
Add support to new Rocket Websocket implementation and push notifications

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,32 @@ SMTP_SSL=SSLv3
 SMTP_USERNAME=apikey
 SMTP_PASSWORD=
 
+#################
+### WebSocket ###
+#################
+
+## Enable websocket notifications
+ENABLE_WEBSOCKET=true
+
+##########################
+### Push notifications ###
+##########################
+
+## Enables push notifications (requires key and id from https://bitwarden.com/host)
+## Details about mobile client push notification:
+## - https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification
+PUSH_ENABLED=true
+PUSH_INSTALLATION_ID=
+PUSH_INSTALLATION_KEY=
+
+# WARNING: Do not modify the following settings unless you fully understand their implications!
+# Default Push Relay and Identity URIs
+# PUSH_RELAY_URI=https://push.bitwarden.com
+# PUSH_IDENTITY_URI=https://identity.bitwarden.com
+# European Union Data Region Settings
+# If you have selected "European Union" as your data region, use the following URIs instead.
+# PUSH_RELAY_URI=https://api.bitwarden.eu
+# PUSH_IDENTITY_URI=https://identity.bitwarden.eu
 
 ### BITWARDEN VARIABLES ###
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ $ sudo journalctl -u google-startup-scripts.service
 
 Now the script will wait until a reboot is pending and then schedule a reboot for the time configured in the script.
 
+## Configure Push Notifications(_optional_)
+From `1.29.0`,Vaultwarden support automatically sync in mobile app depends on push notifications.
+
+1. Go to https://bitwarden.com/host/ insert your email address and you'll get an INSTALLATION ID and KEY.
+
+2. Insert the correct ID and the KEY from the previous step into `.env` file:
+
+```yaml
+PUSH_ENABLED=true
+PUSH_INSTALLATION_ID=
+PUSH_INSTALLATION_KEY=
+```
+
 ## Step 3: Start Services
 
 To start up, use `docker-compose`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3'
-
-
 services:
   bitwarden:
     # Standard Bitwarden is very resource-heavy and cannot run on micro cloud instances
@@ -13,7 +10,7 @@ services:
     - ${PWD}/bitwarden:/data
     environment:
     - LOG_FILE=/dev/stdout
-    - WEBSOCKET_ENABLED=true            # required for websockets
+    - ENABLE_WEBSOCKET=true
     - SHOW_PASSWORD_HINT=false
     - DOMAIN=https://${DOMAIN}          # DOMAIN is set in .env but doesn't have protocol prefix
     - SMTP_FROM_NAME=Bitwarden (${DOMAIN})
@@ -42,7 +39,7 @@ services:
     - ${PWD}/nginx/sites-enabled:/etc/nginx/sites-enabled:ro
   
   cloudflared:
-    image: cloudflare/cloudflared:2021.9.2-amd64
+    image: cloudflare/cloudflared:latest
     restart: always
     user: root
     entrypoint: cloudflared --credentials-file /etc/cloudflared/tunnel.json --url http://proxy:80 tunnel run $CLOUDFLARED_TUNNEL_NAME

--- a/nginx/sites-enabled/bitwarden
+++ b/nginx/sites-enabled/bitwarden
@@ -1,22 +1,28 @@
+# Needed to support websocket connections
+# See: https://nginx.org/en/docs/http/websocket.html
+# Instead of "close" as stated in the above link we send an empty value.
+# Else all keepalive connections will not work.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}
+
 server {
   listen [::]:80;
   listen 80;
-  
+
   server_name _;
-  
+
   location / {
-    proxy_pass http://bitwarden:80;
+  	proxy_http_version 1.1;
+
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-  }
-  location /notifications/hub {
-    proxy_pass http://bitwarden:3012;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-  }
-  location /notifications/hub/negotiate {
+
     proxy_pass http://bitwarden:80;
   }
 }


### PR DESCRIPTION
# support to new Rocket Websocket implementation
In valutwarden v1.31.0 stable,there was a breaking change [https://github.com/dani-garcia/vaultwarden/issues/4024](https://github.com/dani-garcia/vaultwarden/issues/4024),they remove the custom Websocket implementation and add a new Rocket Websocket implementation. So `3012` port is doesn't exist anymore. 

I modify the nginx conf to be compatible with this change.


# support to push notifications
From `1.29.0`,Vaultwarden support automatically sync in mobile app depends on push notifications.[https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-Mobile-Client-push-notification)

A great feature, we deserve it